### PR TITLE
install "fastapi[standard]"

### DIFF
--- a/exercise-1/requirements.txt
+++ b/exercise-1/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
+fastapi[standard]
 pydantic>=2.7.0,<3.0.0


### PR DESCRIPTION
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Description
fastapi was not installing

```
izzy@redknight:~/k8s_class/damian/docker-exercises/exercise-1$ docker run -it debuggin1:latest /bin/bash
root@8cebcbcbf345:/code# fastapi
To use the fastapi command, please install "fastapi[standard]":

        pip install "fastapi[standard]"
```

# How Has This Been Tested?
```
root@8cebcbcbf345:/code# fastapi run app/hello-app.py 

   FastAPI   Starting production server 🚀
 
             Searching for package file structure from directories with __init__.py files
             Importing from /code
 
    module   📁 app
             ├── 🐍 __init__.py
             └── 🐍 hello-app.py
 
      code   Importing the FastAPI app object from the module with the following code:

```

```
izzy@redknight:~/k8s_class/damian/docker-exercises/exercise-1$ docker run -d -p 81:80 fastapi
0a724b6ff0e1ad6558003c2bee3edfjnknbf8c69ede913583704580be675148cecc
```
![Screenshot from 2025-03-03 20-12-11](https://github.com/user-attachments/assets/98737e46-5f51-4f16-9a9b-3f8c8c876c49)